### PR TITLE
Bump nginxinc/nginx-unprivileged image to 1.31.2-alpine3.23

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -16,8 +16,8 @@ services:
       - run:/temp/var/run
       - cache-nginx:/temp/var/cache/nginx
   nginx-after-init:
-    # tag: 1.29-alpine3.22
-    image: nginxinc/nginx-unprivileged@sha256:ab9ff735860df864a690b87f8c1d4e2be988df3c1b925cf4759577f065215a8d
+    # tag: 1.31.2-alpine3.23
+    image: nginxinc/nginx-unprivileged@sha256:a8d5564c3354241473c1e152d5dd3281ab4224edb61b23c291e0bfd9854687a1
     restart: always
     volumes:
       - init-dockerentrypoint:/docker-entrypoint.d


### PR DESCRIPTION
>The PR-template can be found [here](https://github.com/KvalitetsIT/.github/blob/main/PULL_REQUEST_TEMPLATE.md)

# Jira issue
Issue number: **[MA-1511](https://kvalitetsit.atlassian.net/browse/MA-1511)**

<hr/>

# Changes

### What has changed - and why?
<!-- required-text-start -->
Updated nginxinc/nginx-unprivileged image to 1.31.2-alpine3.23, in docker compose file.
<!-- required-text-end -->
# Checklist
> For development: [Developer handbook](https://kvalitetsit.atlassian.net/wiki/x/AYAcrQ)
> 
> For KitHosting: [Operations guide](https://kvalitetsit.atlassian.net/wiki/x/cYAffg) 

<!-- ignore-task-list-start -->
<!-- ignore-task-list-end -->

### Assessment
- [x] I confirm that the change does not introduce any new privacy-related risks (privacy by design and by default)
- [x] I confirm that the change does not introduce any new security-related risks (security by design and by default)

### Verification
- [x] The change has been tested and works as intended
- [x] The change only contains synthetic or anonymized data — no personal data
- [x] The change contains no raw credentials, API keys, or secrets

### Operations
- [x] Rollback is possible and the procedure is known
- [x] It has been confirmed that the correct environment is being updated
- [x] Monitoring and alerting have been considered and are in place for the relevant components

<hr/>

**Remember to add label** 
 > A label should be added to this repo if:
 >  - Repo contains infrastructure components maintained by KIT
 
 `production release tested` (After the PR is tested in prod - No matter the outcome)  
 `production release no impact` (If this pr will not impact production)

